### PR TITLE
Psych::DisallowedClass: Tried to load unspecified class: ActiveSupport::TimeWithZone

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,5 +18,7 @@ module SylviaLuchezV3Backend
     #
     # config.time_zone = "Central Time (US & Canada)"
     config.eager_load_paths << Rails.root.join("lib")
+
+    config.active_record.use_yaml_unsafe_load = true
   end
 end


### PR DESCRIPTION
- [StackOverflow Solution](https://stackoverflow.com/questions/71332602/upgrading-to-ruby-3-1-causes-psychdisallowedclass-exception-when-using-yaml-lo)
- [Rollbar](https://rollbar.com/lluchez/sylvia-luchez-v3-backend/items/88/)